### PR TITLE
Fixes and oead

### DIFF
--- a/rstb/rstb.py
+++ b/rstb/rstb.py
@@ -7,7 +7,7 @@ import os
 import struct
 import typing
 
-import syaz0
+import oead.yaz0
 
 def _get_unpack_endian_character(big_endian: bool):
     return '>' if big_endian else '<'
@@ -182,7 +182,7 @@ class SizeCalculator:
                 with open(str(file), 'rb') as f:
                     file_data = f.read()
             if file_data[0:4] == b'Yaz0':
-                file_data = syaz0.decompress(file_data)
+                file_data = oead.yaz0.decompress(file_data)
         if wiiu:
             size += 0xe4 # res::ResourceMgr constant. Not sure what it is.
             size += info.size_wiiu

--- a/rstb/rstb.py
+++ b/rstb/rstb.py
@@ -165,28 +165,22 @@ class SizeCalculator:
             else:
                 size = os.path.getsize(file)
         else:
-            size = len(file)
+            if file[:4] == b"Yaz0":
+                size = oead.yaz0.get_header(file[:16]).uncompressed_size
+            else:
+                size = len(file)
 
         # Round up the file size to the nearest multiple of 32.
         size = (size + 31) & -32
 
         actual_ext = ext.replace('.s', '.')[1:]
         info = self._factory_info.get(actual_ext, self._factory_info['*'])
-        file_data = bytes()
-        if info.is_complex:
-            if not force:
-                return 0
-            if isinstance(file, bytes):
-                file_data = file
-            else:
-                with open(str(file), 'rb') as f:
-                    file_data = f.read()
-            if file_data[0:4] == b'Yaz0':
-                file_data = oead.yaz0.decompress(file_data)
+        if info.is_complex and not force:
+            return 0
         if wiiu:
             size += 0xe4 # res::ResourceMgr constant. Not sure what it is.
             size += info.size_wiiu
-            size += info.parse_size_wiiu
+            size += getattr(info, "parse_size_wiiu", 0)
 
             if actual_ext == 'beventpack':
                 size += 0xe0
@@ -196,7 +190,7 @@ class SizeCalculator:
         else:
             size += 0x168
             size += info.size_nx
-            size += info.parse_size_nx
+            size += getattr(info, "parse_size_nx", 0)
 
         return size
 

--- a/rstb/util.py
+++ b/rstb/util.py
@@ -4,11 +4,11 @@
 import io
 import os
 from . import rstb
-import syaz0
+import oead.yaz0
 
 def read_rstb(path_to_rstb: str, be: bool) -> rstb.ResourceSizeTable:
     with open(path_to_rstb, 'rb') as file:
-        buf = syaz0.decompress(file.read())
+        buf = oead.yaz0.decompress(file.read())
         return rstb.ResourceSizeTable(buf, be)
 
 def write_rstb(table: rstb.ResourceSizeTable, path_to_rstb: str, be: bool) -> None:
@@ -18,6 +18,6 @@ def write_rstb(table: rstb.ResourceSizeTable, path_to_rstb: str, be: bool) -> No
     with open(path_to_rstb, 'wb+') as file:
         _, extension = os.path.splitext(path_to_rstb)
         if extension.startswith('.s'):
-            file.write(syaz0.compress(buf.getbuffer()))
+            file.write(oead.yaz0.compress(buf.getbuffer()))
         else:
             file.write(buf.getbuffer()) # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries",
     ],
     python_requires='>=3.6',
-    install_requires=['syaz0~=1.0'],
+    install_requires=['oead~=1.1'],
     entry_points = {
         'console_scripts': [
             'rstbtool = rstb.__main__:main',


### PR DESCRIPTION
- Switch `syaz0` to `oead.yaz0`, since several other tools that use `rstb` also use `oead`, so may as well avoid `syaz0` as redundant
- Fix broken `force` argument on `calculate_file_size_with_ext`
- Remove unused `file_data` variable
- Auto unyaz when passing bytes to `calculate_file_size_with_ext` since it already does this for files/paths